### PR TITLE
DCP00{0[0-9],1[0-2]}: Add voting results.

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -50,7 +50,7 @@ should be performed.
 |-
 |[[./dcp-0010/dcp-0010.mediawiki|0010]]||Change PoW/PoS Subsidy Split To 10/80||Active
 |-
-|[[./dcp-0011/dcp-0011.mediawiki|0011]]||Change PoW to BLAKE3 and ASERT||Defined
+|[[./dcp-0011/dcp-0011.mediawiki|0011]]||Change PoW to BLAKE3 and ASERT||Locked In
 |-
-|[[./dcp-0012/dcp-0012.mediawiki|0012]]||Change PoW/PoS Subsidy Split To 1/89||Defined
+|[[./dcp-0012/dcp-0012.mediawiki|0012]]||Change PoW/PoS Subsidy Split To 1/89||Locked In
 |}

--- a/dcp-0000/dcp-0000.mediawiki
+++ b/dcp-0000/dcp-0000.mediawiki
@@ -152,6 +152,8 @@ changes must make use of a voting agenda.
 
 The voting agenda definition should be of the following form:
 
+=====Voting Agenda Params=====
+
 {|
 !Name!!Setting
 |-
@@ -178,6 +180,24 @@ The voting agenda definition should be of the following form:
 |-
 |option 2||''short description of the choice''||''value of choice in hex (Bit #)''
 |}
+|}
+
+Additionally, once the voting has completed, whether the vote passed or failed,
+a voting results section should be added and be of the following form:
+
+=====Voting Results=====
+
+This proposal was approved/rejected by the stakeholder voting process and is now
+active/failed.
+
+{|
+!Status!!Block Hash!!Block Height
+|-
+|Voting Started||''hash of the block''||''height of the block''
+|-
+|Locked In (only if vote was successful)||''hash of the block''||''height of the block''
+|-
+|Active or Failed||''hash of the block''||''height of the block''
 |}
 
 ====Compatibility====

--- a/dcp-0001/dcp-0001.mediawiki
+++ b/dcp-0001/dcp-0001.mediawiki
@@ -241,8 +241,10 @@ on mainnet, under those same circumstances.
 
 ==Deployment==
 
-This agenda will be deployed using the standard Decred on-chain voting
-infrastructure as follows:
+===Voting Agenda Parameters===
+
+This proposal will be deployed to mainnet using the standard Decred on-chain
+voting infrastructure as follows:
 
 {|
 !Name!!Setting
@@ -268,6 +270,24 @@ infrastructure as follows:
 |-
 |yes||change to the new algorithm||0x04 (Bit 2)
 |}
+|}
+
+===Voting Results===
+
+This proposal was approved by the stakeholder voting process and is now active.
+
+Implementations MAY optimize their enforcement activation logic to apply the new
+rules specified by this proposal to the <code>Active</code> block and all of its
+descendants as opposed to tallying historical votes.
+
+{|
+!Status!!Block Hash!!Block Height
+|-
+|Voting Started||00000000000000796ef26549e567547f3a7fdf67cd22b478fef6f4c4a72838f6||133120
+|-
+|Locked In||00000000000000ca1eaaeebcdd21e86c95fc6f0103c8f0b8a868d4b197b46c12||141184
+|-
+|Active||000000000000001bf88e81e7b71194e557bb4df70fda0792fd76a0d50977f789||149248
 |}
 
 ==Compatibility==

--- a/dcp-0002/dcp-0002.mediawiki
+++ b/dcp-0002/dcp-0002.mediawiki
@@ -101,7 +101,9 @@ existing <code>BLAKE256</code> opcode.
 
 ==Deployment==
 
-This agenda will be deployed to mainnet using the standard Decred on-chain
+===Voting Agenda Parameters===
+
+This proposal will be deployed to mainnet using the standard Decred on-chain
 voting infrastructure as follows:
 
 {|
@@ -128,6 +130,24 @@ voting infrastructure as follows:
 |-
 |yes||change to the new consensus rules||0x04 (Bit 2)
 |}
+|}
+
+===Voting Results===
+
+This proposal was approved by the stakeholder voting process and is now active.
+
+Implementations MAY optimize their enforcement activation logic to apply the new
+rules specified by this proposal to the <code>Active</code> block and all of its
+descendants as opposed to tallying historical votes.
+
+{|
+!Status!!Block Hash!!Block Height
+|-
+|Voting Started||0000000000000032798428af98f60111c12d0c4ffdedbce72b8143a0b4444a56||173440
+|-
+|Locked In||000000000000006df125ef4afe8aaf87414cd40aff321f7a075a8c8aadb60b36||181504
+|-
+|Active||000000000000006ffe775adf77b96f18c51fc6ca6f40d982abd4239be1922a0f||189568
 |}
 
 ==Compatibility==

--- a/dcp-0003/dcp-0003.mediawiki
+++ b/dcp-0003/dcp-0003.mediawiki
@@ -270,7 +270,9 @@ other use cases which can make use of these primitives.
 
 ==Deployment==
 
-This agenda will be deployed to mainnet using the standard Decred on-chain
+===Voting Agenda Parameters===
+
+This proposal will be deployed to mainnet using the standard Decred on-chain
 voting infrastructure as follows:
 
 {|
@@ -297,6 +299,24 @@ voting infrastructure as follows:
 |-
 |yes||change to the new consensus rules||0x04 (Bit 2)
 |}
+|}
+
+===Voting Results===
+
+This proposal was approved by the stakeholder voting process and is now active.
+
+Implementations MAY optimize their enforcement activation logic to apply the new
+rules specified by this proposal to the <code>Active</code> block and all of its
+descendants as opposed to tallying historical votes.
+
+{|
+!Status!!Block Hash!!Block Height
+|-
+|Voting Started||0000000000000032798428af98f60111c12d0c4ffdedbce72b8143a0b4444a56||173440
+|-
+|Locked In||000000000000006df125ef4afe8aaf87414cd40aff321f7a075a8c8aadb60b36||181504
+|-
+|Active||000000000000006ffe775adf77b96f18c51fc6ca6f40d982abd4239be1922a0f||189568
 |}
 
 ==Compatibility==

--- a/dcp-0004/dcp-0004.mediawiki
+++ b/dcp-0004/dcp-0004.mediawiki
@@ -77,7 +77,9 @@ proposed implementation satisfies that goal.
 
 ==Deployment==
 
-This agenda will be deployed to mainnet using the standard Decred on-chain
+===Voting Agenda Parameters===
+
+This proposal will be deployed to mainnet using the standard Decred on-chain
 voting infrastructure as follows:
 
 {|
@@ -104,6 +106,24 @@ voting infrastructure as follows:
 |-
 |yes||change to the new consensus rules||0x04 (Bit 2)
 |}
+|}
+
+===Voting Results===
+
+This proposal was approved by the stakeholder voting process and is now active.
+
+Implementations MAY optimize their enforcement activation logic to apply the new
+rules specified by this proposal to the <code>Active</code> block and all of its
+descendants as opposed to tallying historical votes.
+
+{|
+!Status!!Block Hash!!Block Height
+|-
+|Voting Started||00000000000000002579f5071d21b55b7d9e43d996dc578c86505a8055b0d6da||326656
+|-
+|Locked In||00000000000000001e38eae5f63a54a8033b439e326374532d23fcb144a6a3e5||334720
+|-
+|Active||00000000000000000a6f5c5f97877d5945e3302797acd7bbea89db8263dad6a7||342784
 |}
 
 ==Compatibility==

--- a/dcp-0005/dcp-0005.mediawiki
+++ b/dcp-0005/dcp-0005.mediawiki
@@ -701,7 +701,9 @@ multiples of <code>N</code> in <code>[0, N*2^64)</code> and then divides by
 
 ==Deployment==
 
-This agenda will be deployed to mainnet using the standard Decred on-chain
+===Voting Agenda Parameters===
+
+This proposal will be deployed to mainnet using the standard Decred on-chain
 voting infrastructure as follows:
 
 {|
@@ -728,6 +730,24 @@ voting infrastructure as follows:
 |-
 |yes||change to the new consensus rules||0x04 (Bit 2)
 |}
+|}
+
+===Voting Results===
+
+This proposal was approved by the stakeholder voting process and is now active.
+
+Implementations MAY optimize their enforcement activation logic to apply the new
+rules specified by this proposal to the <code>Active</code> block and all of its
+descendants as opposed to tallying historical votes.
+
+{|
+!Status!!Block Hash!!Block Height
+|-
+|Voting Started||000000000000000003f5f9936d3e5d2eb8f6225aa431a73db5c090972972804b||415360
+|-
+|Locked In||00000000000000001d3db0ee2617ea638ffb974b3d4b22e9c5971fd68cb856c8||423424
+|-
+|Active||000000000000000010815bed2c4dc431c34a859f4fc70774223dde788e95a01e||431488
 |}
 
 ==Test Vectors==

--- a/dcp-0006/dcp-0006.mediawiki
+++ b/dcp-0006/dcp-0006.mediawiki
@@ -339,7 +339,9 @@ The following blockchain parameters were added:
 
 ==Deployment==
 
-This agenda will be deployed to mainnet using the standard Decred on-chain
+===Voting Agenda Parameters===
+
+This proposal will be deployed to mainnet using the standard Decred on-chain
 voting infrastructure as follows:
 
 {|
@@ -366,6 +368,24 @@ voting infrastructure as follows:
 |-
 |yes||change to the new consensus rules||0x04 (Bit 2)
 |}
+|}
+
+===Voting Results===
+
+This proposal was approved by the stakeholder voting process and is now active.
+
+Implementations MAY optimize their enforcement activation logic to apply the new
+rules specified by this proposal to the <code>Active</code> block and all of its
+descendants as opposed to tallying historical votes.
+
+{|
+!Status!!Block Hash!!Block Height
+|-
+|Voting Started||000000000000000006005a7e67eafc7fdc65909d10498bed4093d926d7b5318e||536320
+|-
+|Locked In||000000000000000012449cc1cc38a6e41294ed9525f7e64ab39f0de8801c8d38||544384
+|-
+|Active||00000000000000001c6fc262b2673d94827f87daa329b0bdeb7866562ef919cf||552448
 |}
 
 ==Compatibility==

--- a/dcp-0007/dcp-0007.mediawiki
+++ b/dcp-0007/dcp-0007.mediawiki
@@ -121,7 +121,9 @@ policy.
 
 ==Deployment==
 
-This agenda will be deployed to mainnet using the standard Decred on-chain
+===Voting Agenda Parameters===
+
+This proposal will be deployed to mainnet using the standard Decred on-chain
 voting infrastructure as follows:
 
 {|
@@ -149,6 +151,24 @@ in DCP0007
 |-
 |yes||change to the new consensus rules||0x04 (Bit 2)
 |}
+|}
+
+===Voting Results===
+
+This proposal was approved by the stakeholder voting process and is now active.
+
+Implementations MAY optimize their enforcement activation logic to apply the new
+rules specified by this proposal to the <code>Active</code> block and all of its
+descendants as opposed to tallying historical votes.
+
+{|
+!Status!!Block Hash!!Block Height
+|-
+|Voting Started||0000000000000000199b4ae1b9fe1649ce0a357e728ca12ad46d453c6e8f4ee5||641152
+|-
+|Locked In||0000000000000000320d41ff60cf34d15ae836a7298c94c0e690f18ff1cfbdfa||649216
+|-
+|Active||00000000000000002f4c6aaf0e9cb4d5a74c238d9bf8b8909e2372776c7c214c||657280
 |}
 
 ==Compatibility==

--- a/dcp-0008/dcp-0008.mediawiki
+++ b/dcp-0008/dcp-0008.mediawiki
@@ -199,7 +199,9 @@ no downsides and therefore is an excellent choice to deploy separately.
 
 ==Deployment==
 
-This agenda will be deployed to mainnet using the standard Decred on-chain
+===Voting Agenda Parameters===
+
+This proposal will be deployed to mainnet using the standard Decred on-chain
 voting infrastructure as follows:
 
 {|
@@ -226,6 +228,24 @@ voting infrastructure as follows:
 |-
 |yes||change to the new consensus rules||0x0010 (Bit 4)
 |}
+|}
+
+===Voting Results===
+
+This proposal was approved by the stakeholder voting process and is now active.
+
+Implementations MAY optimize their enforcement activation logic to apply the new
+rules specified by this proposal to the <code>Active</code> block and all of its
+descendants as opposed to tallying historical votes.
+
+{|
+!Status!!Block Hash!!Block Height
+|-
+|Voting Started||0000000000000000199b4ae1b9fe1649ce0a357e728ca12ad46d453c6e8f4ee5||641152
+|-
+|Locked In||0000000000000000320d41ff60cf34d15ae836a7298c94c0e690f18ff1cfbdfa||649216
+|-
+|Active||00000000000000002f4c6aaf0e9cb4d5a74c238d9bf8b8909e2372776c7c214c||657280
 |}
 
 ==Compatibility==

--- a/dcp-0009/dcp-0009.mediawiki
+++ b/dcp-0009/dcp-0009.mediawiki
@@ -201,7 +201,9 @@ require a valid signature.
 
 ==Deployment==
 
-This agenda will be deployed to mainnet using the standard Decred on-chain
+===Voting Agenda Parameters===
+
+This proposal will be deployed to mainnet using the standard Decred on-chain
 voting infrastructure as follows:
 
 {|
@@ -228,6 +230,24 @@ voting infrastructure as follows:
 |-
 |yes||change to the new consensus rules||0x0040 (Bit 6)
 |}
+|}
+
+===Voting Results===
+
+This proposal was approved by the stakeholder voting process and is now active.
+
+Implementations MAY optimize their enforcement activation logic to apply the new
+rules specified by this proposal to the <code>Active</code> block and all of its
+descendants as opposed to tallying historical votes.
+
+{|
+!Status!!Block Hash!!Block Height
+|-
+|Voting Started||0000000000000000199b4ae1b9fe1649ce0a357e728ca12ad46d453c6e8f4ee5||641152
+|-
+|Locked In||0000000000000000320d41ff60cf34d15ae836a7298c94c0e690f18ff1cfbdfa||649216
+|-
+|Active||00000000000000002f4c6aaf0e9cb4d5a74c238d9bf8b8909e2372776c7c214c||657280
 |}
 
 ==Compatibility==

--- a/dcp-0010/dcp-0010.mediawiki
+++ b/dcp-0010/dcp-0010.mediawiki
@@ -183,7 +183,9 @@ time are:
 
 ==Deployment==
 
-This agenda will be deployed to mainnet using the standard Decred on-chain
+===Voting Agenda Parameters===
+
+This proposal will be deployed to mainnet using the standard Decred on-chain
 voting infrastructure as follows:
 
 {|
@@ -210,6 +212,24 @@ voting infrastructure as follows:
 |-
 |yes||change to the new consensus rules||0x0100 (Bit 8)
 |}
+|}
+
+===Voting Results===
+
+This proposal was approved by the stakeholder voting process and is now active.
+
+Implementations MAY optimize their enforcement activation logic to apply the new
+rules specified by this proposal to the <code>Active</code> block and all of its
+descendants as opposed to tallying historical votes.
+
+{|
+!Status!!Block Hash!!Block Height
+|-
+|Voting Started||0000000000000000199b4ae1b9fe1649ce0a357e728ca12ad46d453c6e8f4ee5||641152
+|-
+|Locked In||0000000000000000320d41ff60cf34d15ae836a7298c94c0e690f18ff1cfbdfa||649216
+|-
+|Active||00000000000000002f4c6aaf0e9cb4d5a74c238d9bf8b8909e2372776c7c214c||657280
 |}
 
 ==Compatibility==

--- a/dcp-0011/dcp-0011.mediawiki
+++ b/dcp-0011/dcp-0011.mediawiki
@@ -2,7 +2,7 @@
 DCP: 0011
 Title: Change PoW to BLAKE3 and ASERT
 Author: Dave Collins <davec@decred.org>
-Status: Defined
+Status: Locked In
 Created: 2023-04-13
 License: CC0-1.0
 License-Code: ISC
@@ -624,7 +624,9 @@ increase the block production rate back to the desired target.
 
 ==Deployment==
 
-This agenda will be deployed to mainnet using the standard Decred on-chain
+===Voting Agenda Parameters===
+
+This proposal will be deployed to mainnet using the standard Decred on-chain
 voting infrastructure as follows:
 
 {|
@@ -651,6 +653,21 @@ voting infrastructure as follows:
 |-
 |yes||change to the new consensus rules||0x0004 (Bit 2)
 |}
+|}
+
+===Voting Results===
+
+This proposal was approved by the stakeholder voting process and is now locked
+in and awaiting activation.
+
+{|
+!Status!!Block Hash!!Block Height
+|-
+|Voting Started||0000000000000000d608dc4ec7fcae5c650353db68a77f2954df74c25462f337||778240
+|-
+|Locked In||0000000000000000896042b2b0536a4046e56ef505f20f7301ca7e042a5c218e||786304
+|-
+|Active||TBD||794368
 |}
 
 ==Compatibility==

--- a/dcp-0012/dcp-0012.mediawiki
+++ b/dcp-0012/dcp-0012.mediawiki
@@ -3,7 +3,7 @@ DCP: 0012
 Title: Change PoW/PoS Subsidy Split To 1/89
 Author: Dave Collins <davec@decred.org>
         Jake Yocom-Piatt
-Status: Defined
+Status: Locked In
 Created: 2023-04-13
 License: CC0-1.0
 License-Code: ISC
@@ -174,7 +174,9 @@ an entropy source and providing unforgeable costliness and irreversibility.
 
 ==Deployment==
 
-This agenda will be deployed to mainnet using the standard Decred on-chain
+===Voting Agenda Parameters===
+
+This proposal will be deployed to mainnet using the standard Decred on-chain
 voting infrastructure as follows:
 
 {|
@@ -201,6 +203,21 @@ voting infrastructure as follows:
 |-
 |yes||change to the new consensus rules||0x0040 (Bit 6)
 |}
+|}
+
+===Voting Results===
+
+This proposal was approved by the stakeholder voting process and is now locked
+in and awaiting activation.
+
+{|
+!Status!!Block Hash!!Block Height
+|-
+|Voting Started||0000000000000000d608dc4ec7fcae5c650353db68a77f2954df74c25462f337||778240
+|-
+|Locked In||0000000000000000896042b2b0536a4046e56ef505f20f7301ca7e042a5c218e||786304
+|-
+|Active||TBD||794368
 |}
 
 ==Compatibility==


### PR DESCRIPTION
**This requires #31**.

This adds a new voting results subsection to the deployment section of all DCPs to document the historical blocks at which the voting started as well as the locked in and activation heights.

It also clarifies that implementations may optionally optimize their enforcement activation logic accordingly for those historical activation points as opposed to tallying historical votes in the applicable DCPs.