### PR TITLE
DCP0007: Fix table headers in deployment section.

### DIFF
--- a/dcp-0007/dcp-0007.mediawiki
+++ b/dcp-0007/dcp-0007.mediawiki
@@ -140,7 +140,8 @@ in DCP0007
 |-
 |Mask||0x06 (Bits 1 and 2)
 |-
-|Choices||{| !Choice!!English Description!!Bits
+|Choices||{|
+!Choice!!English Description!!Bits
 |-
 |abstain||abstain voting for change||0x00
 |-


### PR DESCRIPTION
"Choice" and "Bits" headers were not rendered due to a syntax error.